### PR TITLE
Use the console email backend locally.

### DIFF
--- a/nhs_reminder/local_settings.py.sample
+++ b/nhs_reminder/local_settings.py.sample
@@ -1,6 +1,8 @@
 # A secret key!
 SECRET_KEY = 'wombles'
 
+EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
+
 # Your Twilio account SID
 TW_ACCOUNT_SID="xxxxxx"
 

--- a/nhs_reminder/settings.py
+++ b/nhs_reminder/settings.py
@@ -129,6 +129,7 @@ import djcelery
 djcelery.setup_loader()
 BROKER_URL = 'redis://localhost:6379/0'
 
+EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 
 # SECURITY WARNING: keep the secret key used in production secret!
 try:


### PR DESCRIPTION
Prevents accidental spam and also better local development defaults make contributions easier 

Signed-off-by: Chris Lamb chris@chris-lamb.co.uk
