### PR TITLE
Add subscription payments with stripe

### DIFF
--- a/nhs_reminder/local_settings.py.sample
+++ b/nhs_reminder/local_settings.py.sample
@@ -22,6 +22,22 @@ TWILIO_CONFIGS = {
 }
 TWILIO_CONFIG = TWILIO_CONFIGS["default"]
 
+STRIPE_CONFIGS = {
+    # "test": {
+        # "PUBLIC_KEY": "XXX",
+        # "SECRET_KEY": "XXX",
+        # "PLAN_ID": "BOGOF",
+    # },
+    "default": {
+        "PUBLIC_KEY": "XXX",
+        "SECRET_KEY": "XXX", # Both public and secret key
+        # can be found on https://dashboard.stripe.com/account/apikeys
+        "PLAN_ID": "four-pound-a-manth", # The plan used when a user subscribes.
+        # Can be found at https://dashboard.stripe.com/plans
+    }
+}
+STRIPE_CONFIG = STRIPE_CONFIGS["default"]
+
 EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
 
 # Your twilio SMS-enabled phone number
@@ -31,7 +47,3 @@ TW_FROM_NUMBER="+44......"
 # up the TwilML because Ross is too lazy to work out the
 # server name dynamically.
 TW_ROOT_URL="http://127.0.0.1:8000/telephony/info"
-
-STRIPE_PUBLIC_KEY = "pk_test_KVrAfaHNBkN15KR1Oi8pLWL6"
-
-STRIPE_SECRET_KEY = "sk_test_cPNACljvxG4Uw8BnEH2Fi90N"

--- a/nhs_reminder/local_settings.py.sample
+++ b/nhs_reminder/local_settings.py.sample
@@ -1,4 +1,4 @@
-# A secret key!
+# A secret key! Change this!
 SECRET_KEY = 'wombles'
 
 TWILIO_CONFIGS = {
@@ -16,7 +16,7 @@ TWILIO_CONFIGS = {
         "FROM_NUMBER": "0000",  # Your twilio SMS-enabled phone number
         # The root URL from where the Twilio service can pick
         # up the TwilML because Ross is too lazy to work out the
-        # server name dynamically.
+         # server name dynamically.
         "ROOT_URL": "http://127.0.0.1:8000/telephony/info"
     }
 }
@@ -24,3 +24,14 @@ TWILIO_CONFIG = TWILIO_CONFIGS["default"]
 
 EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
 
+# Your twilio SMS-enabled phone number
+TW_FROM_NUMBER="+44......"
+
+# The root URL from where the Twilio service can pick
+# up the TwilML because Ross is too lazy to work out the
+# server name dynamically.
+TW_ROOT_URL="http://127.0.0.1:8000/telephony/info"
+
+STRIPE_PUBLIC_KEY = "pk_test_KVrAfaHNBkN15KR1Oi8pLWL6"
+
+STRIPE_SECRET_KEY = "sk_test_cPNACljvxG4Uw8BnEH2Fi90N"

--- a/nhs_reminder/settings.py
+++ b/nhs_reminder/settings.py
@@ -44,6 +44,7 @@ INSTALLED_APPS = (
     'rest_framework',
     'allauth',
     'allauth.account',
+    'payments'
 )
 
 MIDDLEWARE_CLASSES = (

--- a/nhs_reminder/urls.py
+++ b/nhs_reminder/urls.py
@@ -34,4 +34,5 @@ urlpatterns = [
     url('^reminder/', include("reminder.urls")),
     url(r'^api/', include(router.urls)),
     url(r'^accounts/', include('allauth.urls')),
+    url('^payments/', include("payments.urls")),
 ]

--- a/payments/admin.py
+++ b/payments/admin.py
@@ -1,0 +1,11 @@
+from django.contrib import admin
+
+from .models import Subscription
+# Register your models here.
+
+@admin.register(Subscription)
+class Subscription(admin.ModelAdmin):
+    list_display = [
+        'id',
+        'stripe_subscription_id',
+    ]

--- a/payments/forms.py
+++ b/payments/forms.py
@@ -1,0 +1,5 @@
+from django import forms
+
+
+class StripeForm(forms.Form):
+    stripeToken = forms.CharField()

--- a/payments/migrations/0001_initial.py
+++ b/payments/migrations/0001_initial.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='Subscription',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('stripe_subscription_id', models.CharField(max_length=100, blank=True)),
+                ('user', models.OneToOneField(to=settings.AUTH_USER_MODEL)),
+            ],
+        ),
+    ]

--- a/payments/migrations/0002_auto_20150713_1453.py
+++ b/payments/migrations/0002_auto_20150713_1453.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('payments', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.RenameField(
+            model_name='subscription',
+            old_name='user',
+            new_name='owner',
+        ),
+    ]

--- a/payments/models.py
+++ b/payments/models.py
@@ -1,0 +1,6 @@
+from django.db import models
+from django.contrib.auth.models import User
+
+class Subscription(models.Model):
+    owner = models.OneToOneField(User)
+    stripe_subscription_id = models.CharField(blank=True, max_length=100)

--- a/payments/tests.py
+++ b/payments/tests.py
@@ -1,0 +1,3 @@
+from django.test import TestCase
+
+# Create your tests here.

--- a/payments/urls.py
+++ b/payments/urls.py
@@ -1,0 +1,10 @@
+from django.conf.urls import patterns, url
+from django.contrib.auth.decorators import login_required
+
+from .views import SubscribeView, SuccessView
+
+urlpatterns = patterns(
+    '',
+    url(r'^subscribe/$', login_required(SubscribeView.as_view()), name='subscribe'),
+    url(r'^thank_you/$', login_required(SuccessView.as_view()), name='thank_you'),
+)

--- a/payments/views.py
+++ b/payments/views.py
@@ -1,0 +1,49 @@
+import stripe
+
+from django.conf import settings
+from django.core.urlresolvers import reverse_lazy, reverse
+from django.views.generic import FormView, TemplateView
+from django.http import HttpResponseRedirect, HttpResponseForbidden
+from django.contrib import messages
+
+from .models import Subscription
+
+from .forms import StripeForm
+
+
+class StripeMixin(object):
+    def get_context_data(self, **kwargs):
+        context = super(StripeMixin, self).get_context_data(**kwargs)
+        context['publishable_key'] = settings.STRIPE_PUBLIC_KEY
+        context['email'] = self.request.user.email
+        return context
+
+
+class SuccessView(TemplateView):
+    template_name = 'payments/thank_you.html'
+
+    def get(self, request):
+        return HttpResponseRedirect(reverse("reminder_new"))
+
+
+class SubscribeView(StripeMixin, FormView):
+    template_name = 'please_subscribe.html'
+    form_class = StripeForm
+    success_url = reverse_lazy('thank_you')
+
+    def form_valid(self, form):
+        stripe.api_key = settings.STRIPE_SECRET_KEY
+
+        customer_data = {
+            'description': 'Some Customer Data',
+            'card': form.cleaned_data['stripeToken']
+        }
+        customer = stripe.Customer.create(**customer_data)
+
+        subscription = customer.subscriptions.create(plan="four-pound-a-manth")
+
+        s = Subscription(stripe_subscription_id=subscription.id,owner_id=self.request.user.id)
+        s.save()
+
+        messages.success(self.request, 'Your subscription has been setup succesfully')
+        return super(SubscribeView, self).form_valid(form)

--- a/payments/views.py
+++ b/payments/views.py
@@ -14,7 +14,7 @@ from .forms import StripeForm
 class StripeMixin(object):
     def get_context_data(self, **kwargs):
         context = super(StripeMixin, self).get_context_data(**kwargs)
-        context['publishable_key'] = settings.STRIPE_PUBLIC_KEY
+        context['publishable_key'] = settings.STRIPE_CONFIG["PUBLIC_KEY"]
         context['email'] = self.request.user.email
         return context
 
@@ -32,7 +32,7 @@ class SubscribeView(StripeMixin, FormView):
     success_url = reverse_lazy('thank_you')
 
     def form_valid(self, form):
-        stripe.api_key = settings.STRIPE_SECRET_KEY
+        stripe.api_key = settings.STRIPE_CONFIG["SECRET_KEY"]
 
         customer_data = {
             'description': 'Some Customer Data',
@@ -40,7 +40,7 @@ class SubscribeView(StripeMixin, FormView):
         }
         customer = stripe.Customer.create(**customer_data)
 
-        subscription = customer.subscriptions.create(plan="four-pound-a-manth")
+        subscription = customer.subscriptions.create(plan=settings.STRIPE_CONFIG["PLAN_ID"])
 
         s = Subscription(stripe_subscription_id=subscription.id,owner_id=self.request.user.id)
         s.save()

--- a/reminder/static/css/main.css
+++ b/reminder/static/css/main.css
@@ -16,6 +16,10 @@ General
 Site structure
 -------- */
 
+html {
+		font-family: "Helvetica", Arial, sans-serif;
+}
+
 body {
 	background: #1C3048;
 }
@@ -27,7 +31,7 @@ body {
 	padding-top: 0.5em;
 }
 
-.site_header .container { 
+.site_header .container {
 	position: relative;
 }
 
@@ -50,8 +54,7 @@ body {
 
 .site_header .site_nav li {
 	float: left;
-	font-weight: lighter;
-	font-size: 0.8em;
+	font-size: 0.9em;
 	margin: 1.2em 1em;
 		text-align: center;
 }
@@ -130,6 +133,14 @@ body {
 	max-width: 450px;
 }
 
+#messages {
+	background: #fff;
+}
+
+#messages .alert {
+	margin-top: 20px;
+}
+
 /* --------
 Create reminder form
 -------- */
@@ -152,6 +163,7 @@ Create reminder form
 	padding: 6px 12px;
 	vertical-align: middle;
 	width: 48.5%;
+	color: #ccc;
 }
 
 #message-selector label+label {
@@ -202,6 +214,11 @@ Create reminder form
 	max-width: 100%;
 	padding: 1em 1.5em;
 	width: 100%;
+}
+
+#content #reminder-schedule p.label {
+	color: #333;
+	text-align: left;
 }
 
 #content #reminder-schedule p {

--- a/reminder/views.py
+++ b/reminder/views.py
@@ -1,11 +1,18 @@
-from django.shortcuts import render, redirect
+from django.shortcuts import render, redirect, get_object_or_404
 from django.contrib.auth.decorators import login_required
-
+from django.core.urlresolvers import reverse
+from django.http import HttpResponseRedirect, HttpResponseForbidden
+from django.contrib import messages
+from django.views.generic import FormView, TemplateView
+from .models import Reminder
 
 @login_required
 def new_reminder(request):
-    return render(request, 'new_reminder.html')
 
+    if hasattr(request.user, "subscription"):
+        return render(request, 'new_reminder.html')
+    else:
+        return HttpResponseRedirect(reverse("subscribe"))
 
 @login_required
 def list_reminders(request):

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ pytz==2015.4
 redis==2.10.3
 requests==2.7.0
 twilio==4.3.0
+stripe==1.23.0

--- a/templates/base.html
+++ b/templates/base.html
@@ -8,8 +8,7 @@
     <title>Take Your Meds - Phone reminders to help you and yours remember to take your medication</title>
 
     <link href='http://fonts.googleapis.com/css?family=Merriweather:300,400,700' rel='stylesheet' type='text/css' />
-    <!-- <link href="/static/css/bootstrap.min.css" rel="stylesheet" media="screen" /> -->
-
+    <link href="/static/css/bootstrap.min.css" rel="stylesheet" media="screen" />
     <link href="/static/css/normalize.css" rel="stylesheet" media="screen" />
     <link href="/static/css/main.css" rel="stylesheet" media="screen" />
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -7,7 +7,9 @@
     <meta name="robots" content="noindex, nofollow">
     <title>Take Your Meds - Phone reminders to help you and yours remember to take your medication</title>
 
-    <link href='//fonts.googleapis.com/css?family=Merriweather:300,400,700' rel='stylesheet' type='text/css' />
+    <link href='http://fonts.googleapis.com/css?family=Merriweather:300,400,700' rel='stylesheet' type='text/css' />
+    <!-- <link href="/static/css/bootstrap.min.css" rel="stylesheet" media="screen" /> -->
+
     <link href="/static/css/normalize.css" rel="stylesheet" media="screen" />
     <link href="/static/css/main.css" rel="stylesheet" media="screen" />
 
@@ -35,12 +37,19 @@
             <li><a href="/accounts/signup/">Register</a></li>
             <li><a href="/accounts/login/">Login</a></li>
             {% endif %}
-
         </ul>
 
     </div>
 
 </header>
+
+<div id="messages">
+    <div class="container">
+        {% for message in messages %}
+            <div class="alert alert-{{ message.tags }}">{{ message }}</div>
+        {% endfor %}
+    </div>
+</div>
 
 {% block content %}
 {% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -6,15 +6,6 @@
 {%block bodyclass%}home{%endblock%}
 
 {% block content %}
-<div id="hero">
-
-	<div class="container box-sizing-border clearfix">
-		<h1>Simple medication reminders <br />over the phone for you and yours</h1>
-		<a href="/reminder/new" class="submit">Set up a reminder now</a>
-	</div>
-
-</div>
-
 <div id="introduction">
 	<div class="container">
 		<p><strong>Take Your Meds</strong> is a telephone service to help you remember to take your medication. It's easy to set up, and you can start receiving your reminder phonecalls today.</p>

--- a/templates/index.html
+++ b/templates/index.html
@@ -6,6 +6,15 @@
 {%block bodyclass%}home{%endblock%}
 
 {% block content %}
+<div id="hero">
+
+       <div class="container box-sizing-border clearfix">
+               <h1>Simple medication reminders <br />over the phone for you and yours</h1>
+               <a href="/reminder/new" class="submit">Set up a reminder now</a>
+       </div>
+
+</div>
+
 <div id="introduction">
 	<div class="container">
 		<p><strong>Take Your Meds</strong> is a telephone service to help you remember to take your medication. It's easy to set up, and you can start receiving your reminder phonecalls today.</p>

--- a/templates/payments/subscribe.html
+++ b/templates/payments/subscribe.html
@@ -1,0 +1,57 @@
+{% extends "account/base.html" %}
+
+{% block extra_js %}
+{% endblock %}
+
+
+{% block bodyclass %}payment{% endblock %}
+
+{% load i18n %}
+
+{% block head_title %}{% trans "Subscribe" %}{% endblock %}
+
+{% block content %}
+
+
+{% if form.errors %}
+  <div class="alert alert-danger">
+    <ul class="errorlist">
+      {% for key, value in form.errors.items %}
+      <li>{% if key != '__all__' %}{{ key }} {% endif %}{{ value }}</li>
+      {% endfor %}
+    </ul>
+  </div>
+{% endif %}
+
+
+<div class="col-md-4 col-md-offset-4 col-sm-4 col-sm-offset-4" style="margin-top:30px;">
+  <div class="well">
+    <h1>{% trans "Subscribe" %}</h1>
+
+    <p>{% blocktrans %}Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.{% endblocktrans %}</p>
+
+    <form action="" method="post">
+      {% csrf_token %}
+
+      <article>
+        <label>
+          <span>Amount is £5.00</span>
+        </label>
+      </article>
+
+      <script src="https://checkout.stripe.com/checkout.js" class="stripe-button"
+              data-name="Take Your Meds"
+              data-description="30 day free trial, then £3.00 p/m"
+              data-key="{{ publishable_key }}"
+              data-email="{{ email }}"
+              data-currency="gbp"
+              data-label="Subscribe now"
+              data-panel-label="Start free trial"></script>
+
+      <input type="hidden" name="stripe_token" />
+    </form>
+  </div>
+</div>
+
+<div class="clearfix"></div>
+{% endblock %}

--- a/templates/payments/thank_you.html
+++ b/templates/payments/thank_you.html
@@ -1,0 +1,11 @@
+{% extends "base.html" %}
+
+{% block extra_js %}
+{% endblock %}
+
+{%block bodyclass%}home{%endblock%}
+
+{% block content %}
+Thanks
+
+{%endblock%}

--- a/templates/please_subscribe.html
+++ b/templates/please_subscribe.html
@@ -1,0 +1,56 @@
+{% extends "base.html" %}
+
+{% block extra_js %}
+<script type="text/javascript">
+
+    var post_url = "/api/reminders/";
+
+</script>
+{% endblock %}
+
+{% block content %}
+<div id="content">
+
+    <header class="content_header">
+
+        <h1>Just a sec…</h1>
+        <p>You're just two clicks from getting started with Take Your Meds</p>
+
+    </header>
+
+    <div class="container">
+
+        <ul class="list-group">
+            <li class="list-group-item">First month free, then just £3/month for unlimited reminders.</li>
+            <li class="list-group-item">No minimum term.</li>
+            <li class="list-group-item">Secure payment gateway.</li>
+            <li class="list-group-item">24/7 support if you have any questions.</li>
+        </ul>
+
+        <form action="" method="post">
+          {% csrf_token %}
+
+          <script src="https://checkout.stripe.com/checkout.js" class="stripe-button"
+                  data-name="Take Your Meds"
+                  data-description="30 day free trial, then £3.00 p/m"
+                  data-key="{{ publishable_key }}"
+                  data-email="{{ email }}"
+                  data-currency="gbp"
+                  data-label="Subscribe now"
+                  data-panel-label="Start free trial"></script>
+
+          <input type="hidden" name="stripe_token" />
+        </form>
+
+    </div>
+
+    <div class="clearfix"></div>
+
+</div>
+
+<div class="success-message">
+    <p><strong>Thanks!</strong> Your reminders have been successfully set up.</p>
+</div>
+
+{% endblock %}
+


### PR DESCRIPTION
- Adds new payment app
- Integrates with stripe using stripe checkout https://stripe.com/docs/checkout
- Adds a Subscription model with a 1-1 relation.
- Asks a user to subscribe when they try to make a new reminder and have not subscribed before
- Tracks the subscription id sent back from stripe for later use

Flaws:
- Although we're storing an ID sent back from stripe, we're not tracking subscriptions right now. Figured this isn't important until we're actually receiving subscriptions. Also, payments may not be used at all so no point in writing too much payment code if we're not going to use it.

Other changes:
- Display flash messages
- Added the hero section back to the homepage, which got deleted for some reason.
- Add back the bootstrap css file
